### PR TITLE
Refactor AppError testing infrastructure to use TestFactory pattern

### DIFF
--- a/AppPackages/Domain/Sources/Entities/AppError.swift
+++ b/AppPackages/Domain/Sources/Entities/AppError.swift
@@ -259,185 +259,127 @@ public enum ErrorCategory: String, CaseIterable {
     case unknown
 }
 
-// MARK: - Test Error (DEBUG only)
+// MARK: - Test Helpers
 
 #if DEBUG
-    /// Unified test error for mocking failures across all test suites
-    /// This replaces the individual MockError enums in each test file
-    public enum TestError: Error, Equatable, CaseIterable {
-        // MARK: - Generic Test Errors
+    public extension AppError {
+        /// Factory methods for creating test-specific AppError instances
+        enum TestFactory {
+            // MARK: - Generic Test Errors
 
-        case generic
-        case timeout
-        case forbidden
-
-        // MARK: - Device-Specific Test Errors
-
-        case deviceNotFound
-        case deviceAlreadyExists
-        case deviceConnectionFailed
-        case deviceCommandFailure
-        case invalidDevice
-
-        // MARK: - MQTT-Specific Test Errors
-
-        case mqttError
-        case mqttConnectionFailed
-        case mqttPublishFailed
-        case mqttSubscriptionFailed
-
-        // MARK: - Data-Specific Test Errors
-
-        case persistenceError
-        case serializationError
-        case deserializationError
-        case cacheError
-        case validationError
-
-        // MARK: - Discovery-Specific Test Errors
-
-        case discoveryFailure
-        case discoveryTimeout
-        case noDevicesFound
-
-        // MARK: - Repository-Specific Test Errors
-
-        case repositoryError
-        case addDeviceFailure
-        case removeDeviceFailure
-        case getDevicesFailure
-        case subscriptionFailure
-        case commandSendFailure
-        case invalidTopic
-        case stateRetrievalError
-
-        // MARK: - Use Case-Specific Test Errors
-
-        case useCaseExecutionFailed
-        case invalidParameters
-        case preconditionFailed
-        case postconditionFailed
-
-        // MARK: - App Init Errors
-
-        case initializationError
-    }
-
-    extension TestError: LocalizedError {
-        public var errorDescription: String? {
-            switch self {
-            case .generic:
-                "A generic test error occurred"
-            case .timeout:
-                "Test operation timed out"
-            case .forbidden:
-                "Test forbidden access"
-            case .deviceNotFound:
-                "Test device not found"
-            case .deviceAlreadyExists:
-                "Test device already exists"
-            case .deviceConnectionFailed:
-                "Test device connection failed"
-            case .deviceCommandFailure:
-                "Test device command failed"
-            case .invalidDevice:
-                "Test invalid device"
-            case .mqttError:
-                "Test MQTT error"
-            case .mqttConnectionFailed:
-                "Test MQTT connection failed"
-            case .mqttPublishFailed:
-                "Test MQTT publish failed"
-            case .mqttSubscriptionFailed:
-                "Test MQTT subscription failed"
-            case .persistenceError:
-                "Test persistence error"
-            case .serializationError:
-                "Test serialization error"
-            case .deserializationError:
-                "Test deserialization error"
-            case .cacheError:
-                "Test cache error"
-            case .validationError:
-                "Test validation error"
-            case .discoveryFailure:
-                "Test discovery failure"
-            case .discoveryTimeout:
-                "Test discovery timeout"
-            case .noDevicesFound:
-                "Test no devices found"
-            case .repositoryError:
-                "Test repository error"
-            case .addDeviceFailure:
-                "Test add device failure"
-            case .removeDeviceFailure:
-                "Test remove device failure"
-            case .getDevicesFailure:
-                "Test get devices failure"
-            case .subscriptionFailure:
-                "Test subscription failure"
-            case .commandSendFailure:
-                "Test command send failure"
-            case .invalidTopic:
-                "Test invalid topic"
-            case .stateRetrievalError:
-                "Test state retrieval error"
-            case .useCaseExecutionFailed:
-                "Test use case execution failed"
-            case .invalidParameters:
-                "Test invalid parameters"
-            case .preconditionFailed:
-                "Test precondition failed"
-            case .postconditionFailed:
-                "Test postcondition failed"
-            case .initializationError:
-                "Test app initialization failed"
-            }
-        }
-    }
-
-    // MARK: - Convenience Extensions for Tests
-
-    public extension TestError {
-        /// Creates a TestError that matches the given AppError category
-        static func matching(_ category: ErrorCategory) -> TestError {
-            switch category {
-            case .device:
-                .deviceNotFound
-            case .data:
-                .persistenceError
-            case .discovery:
-                .discoveryFailure
-            case .system:
-                .timeout
-            case .unknown:
-                .generic
-            case .connectivity:
-                .mqttError
-            case .initialization:
-                .initializationError
-            }
-        }
-
-        /// Converts this TestError to the corresponding AppError
-        func asAppError() -> AppError {
-            switch self {
-            case .deviceNotFound:
-                .deviceNotFound(deviceId: "test_device")
-            case .deviceAlreadyExists:
-                .deviceAlreadyExists(deviceId: "test_device")
-            case .deviceConnectionFailed:
-                .deviceConnectionFailed(deviceId: "test_device")
-            case .mqttConnectionFailed:
-                .mqttConnectionFailed("Test MQTT connection failed")
-            case .discoveryFailure:
-                .discoveryFailed(reason: "Test discovery failed")
-            case .persistenceError:
-                .persistenceError(operation: "test_operation")
-            case .timeout:
+            public static var generic: AppError { .unknown() }
+            public static var timeout: AppError {
                 .timeout(operation: "test_operation")
-            default:
-                .unknown(underlying: self)
+            }
+
+            // MARK: - Device Test Errors
+
+            public static var deviceNotFound: AppError {
+                .deviceNotFound(deviceId: "test_device")
+            }
+
+            public static var deviceAlreadyExists: AppError {
+                .deviceAlreadyExists(deviceId: "test_device")
+            }
+
+            public static var deviceConnectionFailed: AppError {
+                .deviceConnectionFailed(deviceId: "test_device")
+            }
+
+            public static var deviceCommandFailure: AppError {
+                .deviceCommandFailed(
+                    deviceId: "test_device",
+                    command: "test_command"
+                )
+            }
+
+            // MARK: - MQTT Test Errors
+
+            public static var mqttError: AppError {
+                .mqttConnectionFailed("Test MQTT error")
+            }
+
+            public static var mqttConnectionFailed: AppError {
+                .mqttConnectionFailed("Test MQTT connection failed")
+            }
+
+            public static var mqttPublishFailed: AppError {
+                .mqttPublishFailed(topic: "test/topic")
+            }
+
+            public static var mqttSubscriptionFailed: AppError {
+                .mqttSubscriptionFailed(topic: "test/topic")
+            }
+
+            // MARK: - Data Test Errors
+
+            public static var persistenceError: AppError {
+                .persistenceError(operation: "test_operation")
+            }
+
+            public static var serializationError: AppError {
+                .serializationError(type: "TestType")
+            }
+
+            public static var deserializationError: AppError {
+                .deserializationError(type: "TestType")
+            }
+
+            public static var cacheError: AppError { .cacheError(
+                key: "test_key",
+                operation: "test_operation"
+            ) }
+            public static var validationError: AppError { .validationError(
+                field: "test_field",
+                reason: "test_reason"
+            ) }
+
+            // MARK: - Discovery Test Errors
+
+            public static var discoveryFailure: AppError {
+                .discoveryFailed(reason: "Test discovery failed")
+            }
+
+            public static var discoveryTimeout: AppError { .discoveryTimeout }
+            public static var noDevicesFound: AppError { .noDevicesDiscovered }
+
+            // MARK: - System Test Errors
+
+            public static var repositoryError: AppError {
+                .persistenceError(operation: "repository_operation")
+            }
+
+            public static var addDeviceFailure: AppError {
+                .deviceAlreadyExists(deviceId: "test_device")
+            }
+
+            public static var removeDeviceFailure: AppError {
+                .deviceNotFound(deviceId: "test_device")
+            }
+
+            public static var subscriptionFailure: AppError {
+                .mqttSubscriptionFailed(topic: "test/topic")
+            }
+
+            public static var commandSendFailure: AppError {
+                .deviceCommandFailed(
+                    deviceId: "test_device",
+                    command: "test_command"
+                )
+            }
+
+            public static var invalidTopic: AppError { .validationError(
+                field: "topic",
+                reason: "invalid format"
+            ) }
+
+            // MARK: - App Init Test Errors
+
+            public static var initializationError: AppError {
+                .initializationError(
+                    component: "test_component",
+                    reason: "test_reason"
+                )
             }
         }
     }

--- a/AppPackages/Domain/Tests/UseCasesTests/AddDeviceUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/AddDeviceUseCaseTests.swift
@@ -54,13 +54,13 @@ struct AddDeviceUseCaseTests {
     func executeWhenRepositoryThrowsError() async {
         // Given
         let discoveredDevice = DiscoveredDevice.mockNew1
-        let expectedError = TestError.repositoryError
+        let expectedError = AppError.TestFactory.repositoryError
         let mockRepository = MockDeviceConnectionRepository()
         mockRepository.addDeviceResult = .failure(expectedError)
         let sut = AddDeviceUseCase(deviceConnectionRepository: mockRepository)
 
         // When/Then
-        await #expect(throws: TestError.repositoryError) {
+        await #expect(throws: AppError.TestFactory.repositoryError) {
             try await sut.execute(discoveredDevice: discoveredDevice)
         }
         #expect(mockRepository.addDeviceCallCount == 1)
@@ -70,13 +70,13 @@ struct AddDeviceUseCaseTests {
     func executeWhenDeviceAlreadyExists() async {
         // Given
         let discoveredDevice = DiscoveredDevice.mockNew1
-        let expectedError = TestError.deviceAlreadyExists
+        let expectedError = AppError.TestFactory.deviceAlreadyExists
         let mockRepository = MockDeviceConnectionRepository()
         mockRepository.addDeviceResult = .failure(expectedError)
         let sut = AddDeviceUseCase(deviceConnectionRepository: mockRepository)
 
         // When/Then
-        await #expect(throws: TestError.deviceAlreadyExists) {
+        await #expect(throws: AppError.TestFactory.deviceAlreadyExists) {
             try await sut.execute(discoveredDevice: discoveredDevice)
         }
     }

--- a/AppPackages/Domain/Tests/UseCasesTests/AddDeviceUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/AddDeviceUseCaseTests.swift
@@ -54,13 +54,13 @@ struct AddDeviceUseCaseTests {
     func executeWhenRepositoryThrowsError() async {
         // Given
         let discoveredDevice = DiscoveredDevice.mockNew1
-        let expectedError = MockError.repositoryFailure
+        let expectedError = TestError.repositoryError
         let mockRepository = MockDeviceConnectionRepository()
         mockRepository.addDeviceResult = .failure(expectedError)
         let sut = AddDeviceUseCase(deviceConnectionRepository: mockRepository)
 
         // When/Then
-        await #expect(throws: MockError.repositoryFailure) {
+        await #expect(throws: TestError.repositoryError) {
             try await sut.execute(discoveredDevice: discoveredDevice)
         }
         #expect(mockRepository.addDeviceCallCount == 1)
@@ -70,13 +70,13 @@ struct AddDeviceUseCaseTests {
     func executeWhenDeviceAlreadyExists() async {
         // Given
         let discoveredDevice = DiscoveredDevice.mockNew1
-        let expectedError = MockError.deviceAlreadyExists
+        let expectedError = TestError.deviceAlreadyExists
         let mockRepository = MockDeviceConnectionRepository()
         mockRepository.addDeviceResult = .failure(expectedError)
         let sut = AddDeviceUseCase(deviceConnectionRepository: mockRepository)
 
         // When/Then
-        await #expect(throws: MockError.deviceAlreadyExists) {
+        await #expect(throws: TestError.deviceAlreadyExists) {
             try await sut.execute(discoveredDevice: discoveredDevice)
         }
     }
@@ -166,11 +166,4 @@ private final class MockDeviceConnectionRepository: DeviceConnectionRepositoryPr
         // Not needed for AddDeviceUseCase tests
         []
     }
-}
-
-// MARK: - Mock Error
-
-private enum MockError: Error, Equatable {
-    case repositoryFailure
-    case deviceAlreadyExists
 }

--- a/AppPackages/Domain/Tests/UseCasesTests/GetDiscoveredDevicesUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/GetDiscoveredDevicesUseCaseTests.swift
@@ -132,7 +132,7 @@ struct GetDiscoveredDevicesUseCaseTests {
     @Test("Execute when repository throws error should propagate error")
     func executeWhenRepositoryThrowsError() async {
         // Given
-        let expectedError = TestError.repositoryError
+        let expectedError = AppError.TestFactory.repositoryError
         let mockRepository = MockDeviceDiscoveryRepository()
         mockRepository.shouldThrowError = true
         mockRepository.errorToThrow = expectedError
@@ -142,7 +142,7 @@ struct GetDiscoveredDevicesUseCaseTests {
             )
 
         // When/Then
-        await #expect(throws: TestError.repositoryError) {
+        await #expect(throws: AppError.TestFactory.repositoryError) {
             try await sut.execute()
         }
         #expect(mockRepository.getDiscoveredDevicesCallCount == 1)
@@ -153,7 +153,7 @@ struct GetDiscoveredDevicesUseCaseTests {
     )
     func executeWhenRepositoryThrowsDeviceNotFoundError() async {
         // Given
-        let expectedError = TestError.deviceNotFound
+        let expectedError = AppError.TestFactory.deviceNotFound
         let mockRepository = MockDeviceDiscoveryRepository()
         mockRepository.shouldThrowError = true
         mockRepository.errorToThrow = expectedError
@@ -163,7 +163,7 @@ struct GetDiscoveredDevicesUseCaseTests {
             )
 
         // When/Then
-        await #expect(throws: TestError.deviceNotFound) {
+        await #expect(throws: AppError.TestFactory.deviceNotFound) {
             try await sut.execute()
         }
     }
@@ -292,7 +292,7 @@ private final class MockDeviceDiscoveryRepository: DeviceDiscoveryRepositoryProt
     var getDiscoveredDevicesCallCount = 0
     var discoveredDevices: [DiscoveredDevice] = []
     var shouldThrowError = false
-    var errorToThrow: Error = TestError.repositoryError
+    var errorToThrow: Error = AppError.TestFactory.repositoryError
 
     func getDiscoveredDevices() async throws -> [DiscoveredDevice] {
         getDiscoveredDevicesCallCount += 1

--- a/AppPackages/Domain/Tests/UseCasesTests/GetDiscoveredDevicesUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/GetDiscoveredDevicesUseCaseTests.swift
@@ -132,7 +132,7 @@ struct GetDiscoveredDevicesUseCaseTests {
     @Test("Execute when repository throws error should propagate error")
     func executeWhenRepositoryThrowsError() async {
         // Given
-        let expectedError = MockError.repositoryFailure
+        let expectedError = TestError.repositoryError
         let mockRepository = MockDeviceDiscoveryRepository()
         mockRepository.shouldThrowError = true
         mockRepository.errorToThrow = expectedError
@@ -142,7 +142,7 @@ struct GetDiscoveredDevicesUseCaseTests {
             )
 
         // When/Then
-        await #expect(throws: MockError.repositoryFailure) {
+        await #expect(throws: TestError.repositoryError) {
             try await sut.execute()
         }
         #expect(mockRepository.getDiscoveredDevicesCallCount == 1)
@@ -153,7 +153,7 @@ struct GetDiscoveredDevicesUseCaseTests {
     )
     func executeWhenRepositoryThrowsDeviceNotFoundError() async {
         // Given
-        let expectedError = MockError.deviceNotFound
+        let expectedError = TestError.deviceNotFound
         let mockRepository = MockDeviceDiscoveryRepository()
         mockRepository.shouldThrowError = true
         mockRepository.errorToThrow = expectedError
@@ -163,7 +163,7 @@ struct GetDiscoveredDevicesUseCaseTests {
             )
 
         // When/Then
-        await #expect(throws: MockError.deviceNotFound) {
+        await #expect(throws: TestError.deviceNotFound) {
             try await sut.execute()
         }
     }
@@ -292,7 +292,7 @@ private final class MockDeviceDiscoveryRepository: DeviceDiscoveryRepositoryProt
     var getDiscoveredDevicesCallCount = 0
     var discoveredDevices: [DiscoveredDevice] = []
     var shouldThrowError = false
-    var errorToThrow: Error = MockError.repositoryFailure
+    var errorToThrow: Error = TestError.repositoryError
 
     func getDiscoveredDevices() async throws -> [DiscoveredDevice] {
         getDiscoveredDevicesCallCount += 1
@@ -312,11 +312,4 @@ private final class MockDeviceDiscoveryRepository: DeviceDiscoveryRepositoryProt
             continuation.finish()
         }
     }
-}
-
-// MARK: - Mock Error
-
-private enum MockError: Error, Equatable {
-    case repositoryFailure
-    case deviceNotFound
 }

--- a/AppPackages/Domain/Tests/UseCasesTests/GetManagedDevicesUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/GetManagedDevicesUseCaseTests.swift
@@ -224,7 +224,7 @@ struct GetManagedDevicesUseCaseTests {
     @Test("Execute when repository throws error should propagate error")
     func executeWhenRepositoryThrowsError() async {
         // Given
-        let expectedError = TestError.repositoryError
+        let expectedError = AppError.TestFactory.repositoryError
         let mockRepository = MockDeviceConnectionRepository()
         mockRepository.shouldThrowError = true
         mockRepository.errorToThrow = expectedError
@@ -233,7 +233,7 @@ struct GetManagedDevicesUseCaseTests {
         )
 
         // When/Then
-        await #expect(throws: TestError.repositoryError) {
+        await #expect(throws: AppError.TestFactory.repositoryError) {
             try await sut.execute()
         }
         #expect(mockRepository.getManagedDevicesCallCount == 1)
@@ -244,7 +244,7 @@ struct GetManagedDevicesUseCaseTests {
     )
     func executeWhenRepositoryThrowsDeviceNotFoundError() async {
         // Given
-        let expectedError = TestError.deviceNotFound
+        let expectedError = AppError.TestFactory.deviceNotFound
         let mockRepository = MockDeviceConnectionRepository()
         mockRepository.shouldThrowError = true
         mockRepository.errorToThrow = expectedError
@@ -253,7 +253,7 @@ struct GetManagedDevicesUseCaseTests {
         )
 
         // When/Then
-        await #expect(throws: TestError.deviceNotFound) {
+        await #expect(throws: AppError.TestFactory.deviceNotFound) {
             try await sut.execute()
         }
     }
@@ -347,7 +347,7 @@ private final class MockDeviceConnectionRepository: DeviceConnectionRepositoryPr
     var removeDeviceCallCount = 0
     var managedDevices: [Device] = []
     var shouldThrowError = false
-    var errorToThrow: Error = TestError.repositoryError
+    var errorToThrow: Error = AppError.TestFactory.repositoryError
 
     func getManagedDevices() async throws -> [Device] {
         getManagedDevicesCallCount += 1

--- a/AppPackages/Domain/Tests/UseCasesTests/GetManagedDevicesUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/GetManagedDevicesUseCaseTests.swift
@@ -224,7 +224,7 @@ struct GetManagedDevicesUseCaseTests {
     @Test("Execute when repository throws error should propagate error")
     func executeWhenRepositoryThrowsError() async {
         // Given
-        let expectedError = MockError.repositoryFailure
+        let expectedError = TestError.repositoryError
         let mockRepository = MockDeviceConnectionRepository()
         mockRepository.shouldThrowError = true
         mockRepository.errorToThrow = expectedError
@@ -233,7 +233,7 @@ struct GetManagedDevicesUseCaseTests {
         )
 
         // When/Then
-        await #expect(throws: MockError.repositoryFailure) {
+        await #expect(throws: TestError.repositoryError) {
             try await sut.execute()
         }
         #expect(mockRepository.getManagedDevicesCallCount == 1)
@@ -244,7 +244,7 @@ struct GetManagedDevicesUseCaseTests {
     )
     func executeWhenRepositoryThrowsDeviceNotFoundError() async {
         // Given
-        let expectedError = MockError.deviceNotFound
+        let expectedError = TestError.deviceNotFound
         let mockRepository = MockDeviceConnectionRepository()
         mockRepository.shouldThrowError = true
         mockRepository.errorToThrow = expectedError
@@ -253,7 +253,7 @@ struct GetManagedDevicesUseCaseTests {
         )
 
         // When/Then
-        await #expect(throws: MockError.deviceNotFound) {
+        await #expect(throws: TestError.deviceNotFound) {
             try await sut.execute()
         }
     }
@@ -347,7 +347,7 @@ private final class MockDeviceConnectionRepository: DeviceConnectionRepositoryPr
     var removeDeviceCallCount = 0
     var managedDevices: [Device] = []
     var shouldThrowError = false
-    var errorToThrow: Error = MockError.repositoryFailure
+    var errorToThrow: Error = TestError.repositoryError
 
     func getManagedDevices() async throws -> [Device] {
         getManagedDevicesCallCount += 1
@@ -369,11 +369,4 @@ private final class MockDeviceConnectionRepository: DeviceConnectionRepositoryPr
         removeDeviceCallCount += 1
         // Not needed for GetManagedDevicesUseCase tests
     }
-}
-
-// MARK: - Mock Error
-
-private enum MockError: Error, Equatable {
-    case repositoryFailure
-    case deviceNotFound
 }

--- a/AppPackages/Domain/Tests/UseCasesTests/RemoveDeviceUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/RemoveDeviceUseCaseTests.swift
@@ -149,7 +149,7 @@ struct RemoveDeviceUseCaseTests {
         let deviceId = "test_device"
         let mockRepository = MockDeviceConnectionRepository()
         mockRepository.shouldThrowErrorOnGet = true
-        mockRepository.errorToThrow = MockError.repositoryFailure
+        mockRepository.errorToThrow = TestError.repositoryError
         let mockMqttManager = MockMQTTConnectionManager()
         let sut = RemoveDeviceUseCase(
             deviceConnectionRepository: mockRepository,
@@ -157,7 +157,7 @@ struct RemoveDeviceUseCaseTests {
         )
 
         // When/Then
-        await #expect(throws: MockError.repositoryFailure) {
+        await #expect(throws: TestError.repositoryError) {
             try await sut.execute(deviceId: deviceId)
         }
 
@@ -175,7 +175,7 @@ struct RemoveDeviceUseCaseTests {
         let mockRepository = MockDeviceConnectionRepository()
         mockRepository.managedDevices = [device]
         mockRepository.shouldThrowErrorOnRemove = true
-        mockRepository.errorToThrow = MockError.removalFailure
+        mockRepository.errorToThrow = TestError.removeDeviceFailure
         let mockMqttManager = MockMQTTConnectionManager()
         let sut = RemoveDeviceUseCase(
             deviceConnectionRepository: mockRepository,
@@ -183,7 +183,7 @@ struct RemoveDeviceUseCaseTests {
         )
 
         // When/Then
-        await #expect(throws: MockError.removalFailure) {
+        await #expect(throws: TestError.removeDeviceFailure) {
             try await sut.execute(deviceId: device.id)
         }
 
@@ -367,7 +367,7 @@ private final class MockDeviceConnectionRepository: DeviceConnectionRepositoryPr
     var managedDevices: [Device] = []
     var shouldThrowErrorOnGet = false
     var shouldThrowErrorOnRemove = false
-    var errorToThrow: Error = MockError.repositoryFailure
+    var errorToThrow: Error = TestError.repositoryError
     var lastRemovedDeviceId: String?
 
     func getManagedDevices() async throws -> [Device] {
@@ -425,12 +425,4 @@ private final class MockMQTTConnectionManager: MQTTConnectionManagerProtocol {
     func publish(topic _: String, payload _: String) async throws {
         // Not needed for RemoveDeviceUseCase tests
     }
-}
-
-// MARK: - Mock Error
-
-private enum MockError: Error, Equatable {
-    case repositoryFailure
-    case removalFailure
-    case deviceNotFound
 }

--- a/AppPackages/Domain/Tests/UseCasesTests/RemoveDeviceUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/RemoveDeviceUseCaseTests.swift
@@ -149,7 +149,7 @@ struct RemoveDeviceUseCaseTests {
         let deviceId = "test_device"
         let mockRepository = MockDeviceConnectionRepository()
         mockRepository.shouldThrowErrorOnGet = true
-        mockRepository.errorToThrow = TestError.repositoryError
+        mockRepository.errorToThrow = AppError.TestFactory.repositoryError
         let mockMqttManager = MockMQTTConnectionManager()
         let sut = RemoveDeviceUseCase(
             deviceConnectionRepository: mockRepository,
@@ -157,7 +157,7 @@ struct RemoveDeviceUseCaseTests {
         )
 
         // When/Then
-        await #expect(throws: TestError.repositoryError) {
+        await #expect(throws: AppError.TestFactory.repositoryError) {
             try await sut.execute(deviceId: deviceId)
         }
 
@@ -175,7 +175,7 @@ struct RemoveDeviceUseCaseTests {
         let mockRepository = MockDeviceConnectionRepository()
         mockRepository.managedDevices = [device]
         mockRepository.shouldThrowErrorOnRemove = true
-        mockRepository.errorToThrow = TestError.removeDeviceFailure
+        mockRepository.errorToThrow = AppError.TestFactory.removeDeviceFailure
         let mockMqttManager = MockMQTTConnectionManager()
         let sut = RemoveDeviceUseCase(
             deviceConnectionRepository: mockRepository,
@@ -183,7 +183,7 @@ struct RemoveDeviceUseCaseTests {
         )
 
         // When/Then
-        await #expect(throws: TestError.removeDeviceFailure) {
+        await #expect(throws: AppError.TestFactory.removeDeviceFailure) {
             try await sut.execute(deviceId: device.id)
         }
 
@@ -367,7 +367,7 @@ private final class MockDeviceConnectionRepository: DeviceConnectionRepositoryPr
     var managedDevices: [Device] = []
     var shouldThrowErrorOnGet = false
     var shouldThrowErrorOnRemove = false
-    var errorToThrow: Error = TestError.repositoryError
+    var errorToThrow: Error = AppError.TestFactory.repositoryError
     var lastRemovedDeviceId: String?
 
     func getManagedDevices() async throws -> [Device] {

--- a/AppPackages/Domain/Tests/UseCasesTests/SendDeviceCommandUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/SendDeviceCommandUseCaseTests.swift
@@ -118,12 +118,12 @@ struct SendDeviceCommandUseCaseTests {
         )
         let mockRepository = MockDeviceCommandRepository()
         await mockRepository.setShouldThrowError(true)
-        await mockRepository.setErrorToThrow(MockError.commandSendFailure)
+        await mockRepository.setErrorToThrow(TestError.commandSendFailure)
         let sut =
             SendDeviceCommandUseCase(deviceCommandRepository: mockRepository)
 
         // When/Then
-        await #expect(throws: MockError.commandSendFailure) {
+        await #expect(throws: TestError.commandSendFailure) {
             try await sut.execute(deviceId: deviceId, command: command)
         }
         #expect(await mockRepository.sendDeviceCommandCallCount == 1)
@@ -142,12 +142,12 @@ struct SendDeviceCommandUseCaseTests {
         )
         let mockRepository = MockDeviceCommandRepository()
         await mockRepository.setShouldThrowError(true)
-        await mockRepository.setErrorToThrow(MockError.deviceNotFound)
+        await mockRepository.setErrorToThrow(TestError.deviceNotFound)
         let sut =
             SendDeviceCommandUseCase(deviceCommandRepository: mockRepository)
 
         // When/Then
-        await #expect(throws: MockError.deviceNotFound) {
+        await #expect(throws: TestError.deviceNotFound) {
             try await sut.execute(deviceId: deviceId, command: command)
         }
     }
@@ -163,12 +163,12 @@ struct SendDeviceCommandUseCaseTests {
         )
         let mockRepository = MockDeviceCommandRepository()
         await mockRepository.setShouldThrowError(true)
-        await mockRepository.setErrorToThrow(MockError.mqttError)
+        await mockRepository.setErrorToThrow(TestError.mqttError)
         let sut =
             SendDeviceCommandUseCase(deviceCommandRepository: mockRepository)
 
         // When/Then
-        await #expect(throws: MockError.mqttError) {
+        await #expect(throws: TestError.mqttError) {
             try await sut.execute(deviceId: deviceId, command: command)
         }
     }
@@ -377,7 +377,7 @@ private actor MockDeviceCommandRepository: DeviceCommandRepositoryProtocol {
     var lastDeviceId: String?
     var lastCommand: Command?
     var shouldThrowError = false
-    var errorToThrow: Error = MockError.commandSendFailure
+    var errorToThrow: Error = TestError.commandSendFailure
 
     func sendDeviceCommand(deviceId: String, command: Command) async throws {
         sendDeviceCommandCallCount += 1
@@ -396,13 +396,4 @@ private actor MockDeviceCommandRepository: DeviceCommandRepositoryProtocol {
     func setErrorToThrow(_ error: Error) {
         errorToThrow = error
     }
-}
-
-// MARK: - Mock Error
-
-private enum MockError: Error, Equatable {
-    case commandSendFailure
-    case deviceNotFound
-    case mqttError
-    case invalidCommand
 }

--- a/AppPackages/Domain/Tests/UseCasesTests/SendDeviceCommandUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/SendDeviceCommandUseCaseTests.swift
@@ -118,12 +118,13 @@ struct SendDeviceCommandUseCaseTests {
         )
         let mockRepository = MockDeviceCommandRepository()
         await mockRepository.setShouldThrowError(true)
-        await mockRepository.setErrorToThrow(TestError.commandSendFailure)
+        await mockRepository
+            .setErrorToThrow(AppError.TestFactory.commandSendFailure)
         let sut =
             SendDeviceCommandUseCase(deviceCommandRepository: mockRepository)
 
         // When/Then
-        await #expect(throws: TestError.commandSendFailure) {
+        await #expect(throws: AppError.TestFactory.commandSendFailure) {
             try await sut.execute(deviceId: deviceId, command: command)
         }
         #expect(await mockRepository.sendDeviceCommandCallCount == 1)
@@ -142,12 +143,13 @@ struct SendDeviceCommandUseCaseTests {
         )
         let mockRepository = MockDeviceCommandRepository()
         await mockRepository.setShouldThrowError(true)
-        await mockRepository.setErrorToThrow(TestError.deviceNotFound)
+        await mockRepository
+            .setErrorToThrow(AppError.TestFactory.deviceNotFound)
         let sut =
             SendDeviceCommandUseCase(deviceCommandRepository: mockRepository)
 
         // When/Then
-        await #expect(throws: TestError.deviceNotFound) {
+        await #expect(throws: AppError.TestFactory.deviceNotFound) {
             try await sut.execute(deviceId: deviceId, command: command)
         }
     }
@@ -163,12 +165,12 @@ struct SendDeviceCommandUseCaseTests {
         )
         let mockRepository = MockDeviceCommandRepository()
         await mockRepository.setShouldThrowError(true)
-        await mockRepository.setErrorToThrow(TestError.mqttError)
+        await mockRepository.setErrorToThrow(AppError.TestFactory.mqttError)
         let sut =
             SendDeviceCommandUseCase(deviceCommandRepository: mockRepository)
 
         // When/Then
-        await #expect(throws: TestError.mqttError) {
+        await #expect(throws: AppError.TestFactory.mqttError) {
             try await sut.execute(deviceId: deviceId, command: command)
         }
     }
@@ -377,7 +379,7 @@ private actor MockDeviceCommandRepository: DeviceCommandRepositoryProtocol {
     var lastDeviceId: String?
     var lastCommand: Command?
     var shouldThrowError = false
-    var errorToThrow: Error = TestError.commandSendFailure
+    var errorToThrow: Error = AppError.TestFactory.commandSendFailure
 
     func sendDeviceCommand(deviceId: String, command: Command) async throws {
         sendDeviceCommandCallCount += 1

--- a/AppPackages/Domain/Tests/UseCasesTests/SubscribeToDeviceStatesUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/SubscribeToDeviceStatesUseCaseTests.swift
@@ -148,13 +148,13 @@ struct SubscribeToDeviceStatesUseCaseTests {
         let stateTopic = "home/device/error/state"
         let mockRepository = MockDeviceStateRepository()
         mockRepository.shouldThrowError = true
-        mockRepository.errorToThrow = MockError.subscriptionFailure
+        mockRepository.errorToThrow = TestError.subscriptionFailure
         let sut =
             SubscribeToDeviceStatesUseCase(deviceStateRepository: mockRepository
             )
 
         // When/Then
-        await #expect(throws: MockError.subscriptionFailure) {
+        await #expect(throws: TestError.subscriptionFailure) {
             try await sut.execute(stateTopic: stateTopic)
         }
         #expect(mockRepository.subscribeToDeviceStateCallCount == 1)
@@ -166,13 +166,13 @@ struct SubscribeToDeviceStatesUseCaseTests {
         let stateTopic = "home/device/mqtt_error/state"
         let mockRepository = MockDeviceStateRepository()
         mockRepository.shouldThrowError = true
-        mockRepository.errorToThrow = MockError.mqttError
+        mockRepository.errorToThrow = TestError.mqttError
         let sut =
             SubscribeToDeviceStatesUseCase(deviceStateRepository: mockRepository
             )
 
         // When/Then
-        await #expect(throws: MockError.mqttError) {
+        await #expect(throws: TestError.mqttError) {
             try await sut.execute(stateTopic: stateTopic)
         }
     }
@@ -185,13 +185,13 @@ struct SubscribeToDeviceStatesUseCaseTests {
         let stateTopic = "invalid/topic/format"
         let mockRepository = MockDeviceStateRepository()
         mockRepository.shouldThrowError = true
-        mockRepository.errorToThrow = MockError.invalidTopic
+        mockRepository.errorToThrow = TestError.invalidTopic
         let sut =
             SubscribeToDeviceStatesUseCase(deviceStateRepository: mockRepository
             )
 
         // When/Then
-        await #expect(throws: MockError.invalidTopic) {
+        await #expect(throws: TestError.invalidTopic) {
             try await sut.execute(stateTopic: stateTopic)
         }
     }
@@ -418,7 +418,7 @@ private final class MockDeviceStateRepository: DeviceStateRepositoryProtocol {
     var lastStateTopic: String?
     var deviceStates: [DeviceState] = []
     var shouldThrowError = false
-    var errorToThrow: Error = MockError.subscriptionFailure
+    var errorToThrow: Error = TestError.subscriptionFailure
 
     func subscribeToDeviceState(stateTopic: String) async throws
         -> AsyncStream<DeviceState> {
@@ -442,13 +442,4 @@ private final class MockDeviceStateRepository: DeviceStateRepositoryProtocol {
         // Not needed for SubscribeToDeviceStatesUseCase tests
         return deviceStates.first { $0.deviceId == deviceId }
     }
-}
-
-// MARK: - Mock Error
-
-private enum MockError: Error, Equatable {
-    case subscriptionFailure
-    case mqttError
-    case invalidTopic
-    case deviceNotFound
 }

--- a/AppPackages/Domain/Tests/UseCasesTests/SubscribeToDeviceStatesUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/SubscribeToDeviceStatesUseCaseTests.swift
@@ -148,13 +148,13 @@ struct SubscribeToDeviceStatesUseCaseTests {
         let stateTopic = "home/device/error/state"
         let mockRepository = MockDeviceStateRepository()
         mockRepository.shouldThrowError = true
-        mockRepository.errorToThrow = TestError.subscriptionFailure
+        mockRepository.errorToThrow = AppError.TestFactory.subscriptionFailure
         let sut =
             SubscribeToDeviceStatesUseCase(deviceStateRepository: mockRepository
             )
 
         // When/Then
-        await #expect(throws: TestError.subscriptionFailure) {
+        await #expect(throws: AppError.TestFactory.subscriptionFailure) {
             try await sut.execute(stateTopic: stateTopic)
         }
         #expect(mockRepository.subscribeToDeviceStateCallCount == 1)
@@ -166,13 +166,13 @@ struct SubscribeToDeviceStatesUseCaseTests {
         let stateTopic = "home/device/mqtt_error/state"
         let mockRepository = MockDeviceStateRepository()
         mockRepository.shouldThrowError = true
-        mockRepository.errorToThrow = TestError.mqttError
+        mockRepository.errorToThrow = AppError.TestFactory.mqttError
         let sut =
             SubscribeToDeviceStatesUseCase(deviceStateRepository: mockRepository
             )
 
         // When/Then
-        await #expect(throws: TestError.mqttError) {
+        await #expect(throws: AppError.TestFactory.mqttError) {
             try await sut.execute(stateTopic: stateTopic)
         }
     }
@@ -185,13 +185,13 @@ struct SubscribeToDeviceStatesUseCaseTests {
         let stateTopic = "invalid/topic/format"
         let mockRepository = MockDeviceStateRepository()
         mockRepository.shouldThrowError = true
-        mockRepository.errorToThrow = TestError.invalidTopic
+        mockRepository.errorToThrow = AppError.TestFactory.invalidTopic
         let sut =
             SubscribeToDeviceStatesUseCase(deviceStateRepository: mockRepository
             )
 
         // When/Then
-        await #expect(throws: TestError.invalidTopic) {
+        await #expect(throws: AppError.TestFactory.invalidTopic) {
             try await sut.execute(stateTopic: stateTopic)
         }
     }
@@ -418,7 +418,7 @@ private final class MockDeviceStateRepository: DeviceStateRepositoryProtocol {
     var lastStateTopic: String?
     var deviceStates: [DeviceState] = []
     var shouldThrowError = false
-    var errorToThrow: Error = TestError.subscriptionFailure
+    var errorToThrow: Error = AppError.TestFactory.subscriptionFailure
 
     func subscribeToDeviceState(stateTopic: String) async throws
         -> AsyncStream<DeviceState> {

--- a/AppPackages/Domain/Tests/UseCasesTests/SubscribeToDiscoveredDevicesUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/SubscribeToDiscoveredDevicesUseCaseTests.swift
@@ -212,13 +212,13 @@ struct SubscribeToDiscoveredDevicesUseCaseTests {
         // Given
         let mockRepository = MockDeviceDiscoveryRepository()
         mockRepository.shouldThrowError = true
-        mockRepository.errorToThrow = TestError.discoveryFailure
+        mockRepository.errorToThrow = AppError.TestFactory.discoveryFailure
         let sut = SubscribeToDiscoveredDevicesUseCase(
             deviceDiscoveryRepository: mockRepository
         )
 
         // When/Then
-        await #expect(throws: TestError.discoveryFailure) {
+        await #expect(throws: AppError.TestFactory.discoveryFailure) {
             try await sut.execute()
         }
         #expect(mockRepository.subscribeToDiscoveredDevicesCallCount == 1)
@@ -229,13 +229,13 @@ struct SubscribeToDiscoveredDevicesUseCaseTests {
         // Given
         let mockRepository = MockDeviceDiscoveryRepository()
         mockRepository.shouldThrowError = true
-        mockRepository.errorToThrow = TestError.mqttError
+        mockRepository.errorToThrow = AppError.TestFactory.mqttError
         let sut = SubscribeToDiscoveredDevicesUseCase(
             deviceDiscoveryRepository: mockRepository
         )
 
         // When/Then
-        await #expect(throws: TestError.mqttError) {
+        await #expect(throws: AppError.TestFactory.mqttError) {
             try await sut.execute()
         }
     }
@@ -449,7 +449,7 @@ private final class MockDeviceDiscoveryRepository: DeviceDiscoveryRepositoryProt
     var getDiscoveredDevicesCallCount = 0
     var discoveredDevices: [[DiscoveredDevice]] = []
     var shouldThrowError = false
-    var errorToThrow: Error = TestError.discoveryFailure
+    var errorToThrow: Error = AppError.TestFactory.discoveryFailure
 
     func subscribeToDiscoveredDevices() async throws
         -> AsyncStream<[DiscoveredDevice]> {

--- a/AppPackages/Domain/Tests/UseCasesTests/SubscribeToDiscoveredDevicesUseCaseTests.swift
+++ b/AppPackages/Domain/Tests/UseCasesTests/SubscribeToDiscoveredDevicesUseCaseTests.swift
@@ -212,13 +212,13 @@ struct SubscribeToDiscoveredDevicesUseCaseTests {
         // Given
         let mockRepository = MockDeviceDiscoveryRepository()
         mockRepository.shouldThrowError = true
-        mockRepository.errorToThrow = MockError.discoveryFailure
+        mockRepository.errorToThrow = TestError.discoveryFailure
         let sut = SubscribeToDiscoveredDevicesUseCase(
             deviceDiscoveryRepository: mockRepository
         )
 
         // When/Then
-        await #expect(throws: MockError.discoveryFailure) {
+        await #expect(throws: TestError.discoveryFailure) {
             try await sut.execute()
         }
         #expect(mockRepository.subscribeToDiscoveredDevicesCallCount == 1)
@@ -229,13 +229,13 @@ struct SubscribeToDiscoveredDevicesUseCaseTests {
         // Given
         let mockRepository = MockDeviceDiscoveryRepository()
         mockRepository.shouldThrowError = true
-        mockRepository.errorToThrow = MockError.mqttError
+        mockRepository.errorToThrow = TestError.mqttError
         let sut = SubscribeToDiscoveredDevicesUseCase(
             deviceDiscoveryRepository: mockRepository
         )
 
         // When/Then
-        await #expect(throws: MockError.mqttError) {
+        await #expect(throws: TestError.mqttError) {
             try await sut.execute()
         }
     }
@@ -449,7 +449,7 @@ private final class MockDeviceDiscoveryRepository: DeviceDiscoveryRepositoryProt
     var getDiscoveredDevicesCallCount = 0
     var discoveredDevices: [[DiscoveredDevice]] = []
     var shouldThrowError = false
-    var errorToThrow: Error = MockError.discoveryFailure
+    var errorToThrow: Error = TestError.discoveryFailure
 
     func subscribeToDiscoveredDevices() async throws
         -> AsyncStream<[DiscoveredDevice]> {
@@ -472,12 +472,4 @@ private final class MockDeviceDiscoveryRepository: DeviceDiscoveryRepositoryProt
         // Not needed for SubscribeToDiscoveredDevicesUseCase tests
         return discoveredDevices.flatMap(\.self)
     }
-}
-
-// MARK: - Mock Error
-
-private enum MockError: Error, Equatable {
-    case discoveryFailure
-    case mqttError
-    case deviceNotFound
 }

--- a/AppPackages/Presentation/Tests/StoresTests/DeviceStoreTests.swift
+++ b/AppPackages/Presentation/Tests/StoresTests/DeviceStoreTests.swift
@@ -66,7 +66,7 @@ struct DeviceStoreTests {
         if case let .error(appError) = store.viewState {
             // The error message should contain our mock error description
             let errorMessage = appError.errorDescription ?? ""
-            #expect(errorMessage.contains("Mock error occurred during testing"))
+            #expect(errorMessage.contains("A generic test error occurred"))
         } else {
             Issue.record("Expected error state, but got: \(store.viewState)")
         }
@@ -231,7 +231,7 @@ private final class MockDeviceConnectionRepository: DeviceConnectionRepositoryPr
     func addDevice(_ discoveredDevice: DiscoveredDevice) async throws
         -> Device {
         if shouldThrowError {
-            throw MockError.testError
+            throw TestError.generic
         }
         return Device(
             id: discoveredDevice.id,
@@ -252,13 +252,13 @@ private final class MockDeviceConnectionRepository: DeviceConnectionRepositoryPr
 
     func removeDevice(deviceId _: String) async throws {
         if shouldThrowError {
-            throw MockError.testError
+            throw TestError.generic
         }
     }
 
     func getManagedDevices() async throws -> [Device] {
         if shouldThrowError {
-            throw MockError.testError
+            throw TestError.generic
         }
         return devices
     }
@@ -321,16 +321,4 @@ private final class MockMQTTConnectionManager: MQTTConnectionManagerProtocol {
 
 private final class MockLogger: LoggerProtocol {
     func log(_: String, level _: OSLogType) {}
-}
-
-private enum MockError: Error, LocalizedError {
-    case testError
-
-    var errorDescription: String? {
-        "Mock error occurred during testing"
-    }
-
-    var localizedDescription: String {
-        errorDescription ?? "Unknown mock error"
-    }
 }

--- a/AppPackages/Presentation/Tests/StoresTests/DeviceStoreTests.swift
+++ b/AppPackages/Presentation/Tests/StoresTests/DeviceStoreTests.swift
@@ -66,7 +66,7 @@ struct DeviceStoreTests {
         if case let .error(appError) = store.viewState {
             // The error message should contain our mock error description
             let errorMessage = appError.errorDescription ?? ""
-            #expect(errorMessage.contains("A generic test error occurred"))
+            #expect(errorMessage.contains("An unexpected error occurred"))
         } else {
             Issue.record("Expected error state, but got: \(store.viewState)")
         }
@@ -231,7 +231,7 @@ private final class MockDeviceConnectionRepository: DeviceConnectionRepositoryPr
     func addDevice(_ discoveredDevice: DiscoveredDevice) async throws
         -> Device {
         if shouldThrowError {
-            throw TestError.generic
+            throw AppError.TestFactory.generic
         }
         return Device(
             id: discoveredDevice.id,
@@ -252,13 +252,13 @@ private final class MockDeviceConnectionRepository: DeviceConnectionRepositoryPr
 
     func removeDevice(deviceId _: String) async throws {
         if shouldThrowError {
-            throw TestError.generic
+            throw AppError.TestFactory.generic
         }
     }
 
     func getManagedDevices() async throws -> [Device] {
         if shouldThrowError {
-            throw TestError.generic
+            throw AppError.TestFactory.generic
         }
         return devices
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md - iOS SwiftUI Development Guide
+
+## Project Overview
+iOS app built with SwiftUI and Swift 6.1, targeting iOS 17.0+
+
+## Development Setup
+```bash
+# Open workspace
+open Argus.xcworkspace
+
+# Build project
+xcodebuild -project Argus.xcodeproj -scheme Argus -destination 'platform=iOS Simulator,name=iPhone 15' build
+
+# Run tests
+xcodebuild test -project Argus.xcodeproj -scheme Argus -destination 'platform=iOS Simulator,name=iPhone 15'
+
+# Clean build
+xcodebuild clean -project Argus.xcodeproj -scheme Argus
+```
+
+## Code Standards
+- Swift 6.1 strict concurrency enabled
+- Use `@MainActor` for UI-related classes
+- Prefer `async/await` over completion handlers
+- Use `@Observable` macro for state management
+- Follow SwiftUI declarative patterns
+
+## Architecture
+- MV+Store
+- Repository pattern for data access
+- Use cases for business logic
+- Stores for state management
+- Clean Architecture principles
+
+## Testing
+```bash
+# Unit tests
+swift test
+
+# UI tests
+xcodebuild test -project Argus.xcodeproj -scheme Argus -destination 'platform=iOS Simulator,name=iPhone 15'
+```
+
+## Code Quality
+```bash
+# SwiftLint (if available)
+swiftlint
+
+# Swift format (if available)
+swift-format --in-place **/*.swift
+```
+
+## Key Patterns
+- Use `@State` for local view state
+- Use `@Observable` for shared state objects
+- Inject dependencies via initializers
+- Handle errors with custom `AppError` types
+- Use `Task` for async operations in views
+
+## Debugging
+- Use `print()` statements sparingly
+- Leverage Xcode breakpoints and console
+- Use `os_log` for production logging
+- Test on both simulator and device
+
+## Common Commands
+- Build: `⌘+B`
+- Run: `⌘+R`
+- Test: `⌘+U`
+- Clean: `⌘+Shift+K`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Ensure the Docker container and test server is running locally to provide test d
 - **Clean Architecture** with clear separation of concerns
 - **MV State Pattern** for reactive UI with Combine
 - **Modular Design** using Swift Package Manager
-- **Real-time Communication** via MQTT 
+- **Real-time Communication** via MQTT
 - **Dependency Injection** Composition Root with State/Store
 - **Router Pattern** for navigation
 - **Async/Await** for modern concurrency
@@ -84,7 +84,7 @@ Argus/
 ├── Packages/
 │   ├── Domain/               # Business logic (no dependencies)
 │   ├── Data/                 # Repository implementations
-│   ├── Presentation/         # UI modules 
+│   ├── Presentation/         # UI modules
 │   ├── Infrastructure/       # Core services and utilities
 │   └── Navigation/           # Routers and Route extensions
 └── README.md
@@ -120,7 +120,7 @@ Open the file Argus/Argus.xcworkspace (not the .xcodeproj).
 - Subsequent Builds: Future builds will be much faster (~5 seconds).
 
 **Run & Test**
-- To run the app: Press Cmd+R 
+- To run the app: Press Cmd+R
 - To run the tests: Press Cmd+U
 
 ## UI/UX Design
@@ -129,7 +129,7 @@ Open the file Argus/Argus.xcworkspace (not the .xcodeproj).
 
 The current interface prioritizes functionality over polish. Potential improvements for future iterations:
 - Enhanced visual design and user experience
-- Improved connection status 
+- Improved connection status
 
 ## Build Configurations
 


### PR DESCRIPTION
## Summary
• Replace individual TestError enum with centralized AppError.TestFactory
• Provide factory methods that return proper AppError instances for testing  
• Update all test files to use TestFactory instead of TestError enum
• Improve test error consistency by using real AppError instances

## Test plan
- [x] Run all unit tests to ensure no regressions
- [x] Verify TestFactory methods return correct AppError types
- [x] Check that test error messages are appropriate
- [x] Validate all test suites still pass with new error pattern

🤖 Generated with [Claude Code](https://claude.ai/code)